### PR TITLE
Organize interface

### DIFF
--- a/HandOfLesser/src/TrackedHand.cpp
+++ b/HandOfLesser/src/TrackedHand.cpp
@@ -104,27 +104,15 @@ void TrackedHand::updateJointLocations(xr::UniqueDynamicSpace& space, XrTime tim
 	Eigen::Vector3f rotationOffsetLocal = this->mPalmLocation.orientation * mainTranslationOffset;
 	this->mPalmLocation.position = rawPosition + rotationOffsetLocal;
 
-	if (this->mSide == XR_HAND_LEFT_EXT)
 	{
-		HOL::display::FinalOffsetLeft.position = mainTranslationOffset;
-		HOL::display::FinalOffsetLeft.orientation = rotationOffsetQuat;
+		HOL::display::HandTransform[this->mSide].rawPose.position = rawPosition;
+		HOL::display::HandTransform[this->mSide].rawPose.orientation = rawOrientation;
 
-		HOL::display::RawPoseLeft.position = rawPosition;
-		HOL::display::RawPoseLeft.orientation = rawOrientation;
+		HOL::display::HandTransform[this->mSide].finalPose.position = this->mPalmLocation.position;
+		HOL::display::HandTransform[this->mSide].finalPose.orientation = this->mPalmLocation.orientation;
 
-		HOL::display::FinalPoseLeft.position = this->mPalmLocation.position;
-		HOL::display::FinalPoseLeft.orientation = this->mPalmLocation.orientation;
-	}
-	else
-	{
-		HOL::display::FinalOffsetRight.position = mainTranslationOffset;
-		HOL::display::FinalOffsetRight.orientation = rotationOffsetQuat;
-
-		HOL::display::RawPoseRight.position = rawPosition;
-		HOL::display::RawPoseRight.orientation = rawOrientation;
-
-		HOL::display::FinalPoseRight.position = this->mPalmLocation.position;
-		HOL::display::FinalPoseRight.orientation = this->mPalmLocation.orientation;
+		HOL::display::HandTransform[this->mSide].finalOffset.position = mainTranslationOffset;
+		HOL::display::HandTransform[this->mSide].finalOffset.orientation = rotationOffsetQuat;
 	}
 }
 

--- a/HandOfLesser/src/display_global.cpp
+++ b/HandOfLesser/src/display_global.cpp
@@ -6,14 +6,6 @@ namespace HOL
 {
 namespace display
 {
-HOL::PoseLocation FinalOffsetLeft;
-HOL::PoseLocation FinalOffsetRight;
-
-HOL::PoseLocation RawPoseLeft;
-HOL::PoseLocation RawPoseRight;
-
-HOL::PoseLocation FinalPoseLeft;
-HOL::PoseLocation FinalPoseRight;
-
+	HandTransformDisplay HandTransform[2];
 } // namespace display
 } // namespace HOL

--- a/HandOfLesser/src/display_global.h
+++ b/HandOfLesser/src/display_global.h
@@ -7,15 +7,15 @@
 
 namespace HOL
 {
+	struct HandTransformDisplay
+	{
+		HOL::PoseLocation finalOffset;
+		HOL::PoseLocation rawPose;
+		HOL::PoseLocation finalPose;
+	};
+
 	namespace display
 	{
-		extern HOL::PoseLocation FinalOffsetLeft;
-		extern HOL::PoseLocation FinalOffsetRight;
-
-		extern HOL::PoseLocation RawPoseLeft;
-		extern HOL::PoseLocation RawPoseRight;
-
-		extern HOL::PoseLocation FinalPoseLeft;
-		extern HOL::PoseLocation FinalPoseRight;
+		extern HandTransformDisplay HandTransform[2];
 	}
 }

--- a/HandOfLesser/src/user_interface.h
+++ b/HandOfLesser/src/user_interface.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <HandOfLesserCommon.h>
 #include <GLFW/glfw3.h>
 
 class UserInterface
@@ -16,10 +17,15 @@ class UserInterface
 		static UserInterface* mCurrent;	// We only have a single window for now
 		void initGLFW();
 		void initImgui();
+		float mScale = 1.f;
 		static void error_callback(int error, const char* description);
 		static void windows_scale_callback(GLFWwindow* window, float xscale, float yscale);
+		float scaleSize(float size);
 
 		void updateStyles(float scale);
+
+		void buildSingleHandTransformDisplay(HOL::HandSide side);
+		void buildHandTransformDisplay();
 
 
 


### PR DESCRIPTION
Organize the interface, separate left/right hand values, reuse code instead of copy-pasting for each hand.

![usAc9Nd](https://github.com/Nordskog/HandOfLesser/assets/8961771/1e3df0df-05b5-47ad-9b84-d0e5655a78f0)
