### PR TITLE
Use googletest unit testing framework with CTest

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "lib/eigen"]
 	path = lib/eigen
 	url = https://gitlab.com/libeigen/eigen.git
+[submodule "lib/googletest"]
+	path = lib/googletest
+	url = https://github.com/google/googletest.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ endif()
 project(HandOfLesser)
 set(CMAKE_CXX_STANDARD 17)
 
+# Silence C++17 deprecation warnings
+add_definitions(-D_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING)
+
 # Needed for CTest
 enable_testing()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,13 @@ endif()
 project(HandOfLesser)
 set(CMAKE_CXX_STANDARD 17)
 
+# Needed for CTest
+enable_testing()
+
+# Needed for GoogleTest
+set(gtest_force_shared_crt ON)
+include(GoogleTest)
+
 # Needed for OpenXR
 add_library(openxr-hpp INTERFACE)
 target_include_directories(openxr-hpp INTERFACE lib/openxr-hpp)
@@ -61,6 +68,7 @@ target_link_libraries(imgui PRIVATE glfw)
 add_subdirectory(lib/openxr_sdk)
 add_subdirectory(lib/openvr)
 add_subdirectory(lib/glfw)
+add_subdirectory(lib/googletest)
 add_subdirectory(HandOfLesserCommon)
 add_subdirectory(HandOfLesser)
 add_subdirectory(HandOfLesserDriver)

--- a/HandOfLesserCommon/CMakeLists.txt
+++ b/HandOfLesserCommon/CMakeLists.txt
@@ -15,3 +15,14 @@ target_include_directories(HandOfLesserCommon
 	INTERFACE include
 	PRIVATE ${OPENVR_INCLUDE_DIR}
 )
+
+add_executable(HandOfLesserCommon.Tests
+	tests/test_example.cpp
+)
+
+target_link_libraries(HandOfLesserCommon.Tests PRIVATE
+	gtest
+	gtest_main
+)
+
+gtest_discover_tests(HandOfLesserCommon.Tests)

--- a/HandOfLesserCommon/tests/test_example.cpp
+++ b/HandOfLesserCommon/tests/test_example.cpp
@@ -1,0 +1,14 @@
+#include <gtest/gtest.h>
+
+int add(int a, int b) {
+	return a + b;
+}
+
+TEST(AdditionTest, HandlesPositiveInput) {
+    EXPECT_EQ(5, add(2, 3));
+}
+
+TEST(AdditionTest, HandlesNegativeInput) {
+    EXPECT_EQ(-1, add(-2, 1));
+    EXPECT_EQ(-3, add(-2, -1));
+}


### PR DESCRIPTION
1. Added lib/googletest git submodule.
2. Updated the CMake configuration to build googletest.
3. Added dummy example with automatic test discovery.
4. Silenced C++17 warnings introduced earlier today.

<img width="688" alt="image" src="https://github.com/Nordskog/HandOfLesser/assets/9294002/1bdce98a-6d2f-4266-9ebf-868385c46324">
