### PR TITLE
Fix missing DartConfiguration.tcl errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set(CMAKE_CXX_STANDARD 17)
 add_definitions(-D_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING)
 
 # Needed for CTest
+include(CTest)
 enable_testing()
 
 # Needed for GoogleTest


### PR DESCRIPTION
```
[ctest] Cannot find file: D:/Projects/HandOfLesser/out/build/x64-debug/DartConfiguration.tcl
[ctest]    Site: 
[ctest]    Build name: (empty)
[ctest] Test project D:/Projects/HandOfLesser/out/build/x64-debug
[ctest] Cannot find file: D:/Projects/HandOfLesser/out/build/x64-debug/DartConfiguration.tcl
```

I was able to reproduce this error when running tests directly from VSCode.