### PR TITLE
workaround for airlink session state restriction

### DIFF
--- a/HandOfLesser/CMakeLists.txt
+++ b/HandOfLesser/CMakeLists.txt
@@ -11,6 +11,7 @@
 	src/TrackedHand.cpp
 	src/user_interface.cpp
 	src/XrUtils.cpp
+	src/openxr_hacks.cpp
 )
 
 find_package(OpenGL REQUIRED)

--- a/HandOfLesser/src/HandOfLesserCore.cpp
+++ b/HandOfLesser/src/HandOfLesserCore.cpp
@@ -1,5 +1,6 @@
 #include "HandOfLesserCore.h"
 #include <thread>
+#include "openxr_hacks.h"
 
 void HandOfLesserCore::init(int serverPort)
 {
@@ -14,6 +15,10 @@ void HandOfLesserCore::init(int serverPort)
 
 	this->mUserInterface = std::make_unique<UserInterface>();
 	this->mUserInterface.get()->init();
+
+	// Only necessary if using Airlink runtime
+	// Doesn't hurt to run otherwise though.
+	HOL::hacks::fixOvrSessionStateRestriction();
 }
 
 void HandOfLesserCore::start()

--- a/HandOfLesser/src/openxr_hacks.cpp
+++ b/HandOfLesser/src/openxr_hacks.cpp
@@ -1,0 +1,223 @@
+#include "openxr_hacks.h"
+
+#include <tchar.h>
+#include <psapi.h>
+#include <iostream>
+#include <iomanip>
+
+namespace HOL::hacks
+{
+HMODULE getModule(HANDLE hProcess, const TCHAR moduleName[])
+{
+	// module meaning dll
+	// all these weird functions use tchar, so I guess we'll use it too.
+
+	HMODULE hMods[1024];
+	DWORD cbNeeded;
+
+	if (EnumProcessModules(hProcess, hMods, sizeof(hMods), &cbNeeded))
+	{
+		for (int i = 0; i < (cbNeeded / sizeof(HMODULE)); i++)
+		{
+			TCHAR szModName[MAX_PATH];
+
+			if (GetModuleFileNameEx(
+					hProcess, hMods[i], szModName, sizeof(szModName) / sizeof(TCHAR)
+				))
+			{
+				if (_tcsstr(szModName, moduleName) != NULL)
+				{
+					std::cout << "Found OVR dll: " << szModName << std::endl;
+					return hMods[i];
+				}
+			}
+		}
+	}
+
+	std::cerr << "Could not find OVR dll!" << std::endl;
+
+	return nullptr;
+}
+
+/// <summary>
+/// Modifies ovr_GetHandPose LibOVRRT64_1.dll and inverts the clause that
+/// presumably checks if the session state is FOCUSED by replacing a jnz instruction with jz
+/// </summary>
+void fixOvrSessionStateRestriction()
+{
+	HANDLE currentProcess = GetCurrentProcess();
+	HMODULE hModule
+		= getModule(currentProcess, _T("\LibOVRRT64_1.dll")); // dll loaded into this memory address
+
+	const BYTE targetInstruction[]
+		= {0x75, 0xFF}; // First byte we're modifying. 0xFF is the next value in the pattern.
+	const BYTE replacementInstruction = 0x74; // Byte we're replacing it with
+
+	// Pattern of bytes surrounding the instructions we are looking for,.
+	// 0xFF denotes a wildcard
+	BYTE targetBytes[] = {
+
+		0x48, 0x8b, 0x05, 0xFF, 0xFF, 0xFF, 0xFF, // mov
+		0x48, 0x85, 0xc0,						  // test
+		0x75, 0x05,								  // jnz
+		0xe8, 0xFF, 0xFF, 0xFF, 0xFF,			  // call
+
+		0x80, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // cmp
+		0x75, 0xFF,								  // jnz	Target!
+
+	};
+
+	// Location of target byte relative to first byte of search pattern
+	int targetOffset = 0;
+	for (int i = 0; i < std::size(targetBytes); i++)
+	{
+		if (targetBytes[i] == targetInstruction[0] && targetBytes[i + 1] == targetInstruction[1])
+		{
+			targetOffset = i;
+			break;
+		}
+	}
+
+	// Look up module size to limit search range
+	MODULEINFO moduleInfo;
+	if (!GetModuleInformation(GetCurrentProcess(), hModule, &moduleInfo, sizeof(moduleInfo)))
+	{
+		std::cerr << "GetModuleInformation failed";
+	}
+
+	size_t moduleSize = moduleInfo.SizeOfImage;
+	BYTE* baseAddress = reinterpret_cast<BYTE*>(hModule);
+	BYTE* targetAddress = baseAddress;
+
+	int foundBytes = 0;
+	int maxBytesFound = 0;
+	bool found = false;
+	BYTE* bestResultAddress = nullptr;
+	BYTE* currentResultStartAddress = nullptr;
+
+	// Loop through the module and find best match for pattern
+	while (targetAddress < baseAddress + moduleSize)
+	{
+		if (*targetAddress == targetBytes[foundBytes] || targetBytes[foundBytes] == 0xFF)
+		{
+			if (foundBytes == 0)
+			{
+				currentResultStartAddress = targetAddress;
+			}
+
+			foundBytes++;
+
+			if (foundBytes > maxBytesFound)
+			{
+				maxBytesFound = foundBytes;
+				bestResultAddress = currentResultStartAddress;
+			}
+
+			targetAddress++;
+		}
+		else
+		{
+			if (foundBytes == 0)
+			{
+				// If we were not on the first byte of the pattern,
+				// skip iterating address so the byte will be compared again
+				// to the beginning of the pattern on the next loop
+				targetAddress++;
+			}
+
+			foundBytes = 0;
+		}
+
+		if (foundBytes == std::size(targetBytes))
+		{
+			found = true;
+			break;
+		}
+	}
+
+	// Print bytes found, for reference
+	if (bestResultAddress != nullptr)
+	{
+		std::cout << _T("Best match for pattern at: ") << static_cast<void*>(bestResultAddress)
+				  << std::endl;
+
+		BYTE* addr = bestResultAddress;
+		for (int i = 0; i < maxBytesFound; i++)
+		{
+			std::cout << std::setw(2) << std::setfill('0') << std::hex << static_cast<int>(*addr)
+					  << " ";
+			addr++;
+		}
+
+		std::cout << std::endl;
+	}
+
+	if (found)
+	{
+		std::cout << "Found all bytes in pattern!" << std::endl;
+
+		// modification target offset in search pattern
+		targetAddress = bestResultAddress + targetOffset;
+	}
+	else
+	{
+		if (bestResultAddress != nullptr)
+		{
+			targetAddress = bestResultAddress + targetOffset;
+
+			if (*bestResultAddress == targetInstruction[0])
+			{
+				targetAddress = bestResultAddress;
+				found = true;
+
+				std::cout << "Incomplete match but found expected instruction. Fingers crossed."
+						  << std::endl;
+			}
+			else
+			{
+				std::cerr << "Could not find address to modify! Probably cannot read hand pose."
+						  << std::endl;
+			}
+		}
+	}
+
+	if (found)
+	{
+		// Print the existing value
+		BYTE currentValue = *targetAddress;
+		std::cout << ("Existing value at offset ") << static_cast<void*>(targetAddress) << (": 0x")
+				  << std::hex << static_cast<int>(currentValue) << std::endl;
+
+		// Nuke protection so we can write to it
+		DWORD oldProtect;
+		if (VirtualProtect(
+				static_cast<LPVOID>(targetAddress),
+				sizeof(char),
+				PAGE_EXECUTE_READWRITE,
+				&oldProtect
+			))
+		{
+			// Modify instruction
+			*targetAddress = replacementInstruction;
+
+			// Restore the original protection
+			VirtualProtect(
+				static_cast<LPVOID>(targetAddress), sizeof(char), oldProtect, &oldProtect
+			);
+
+			std::cout << _T("Instruction modified successfully!") << std::endl;
+		}
+		else
+		{
+			std::cout << _T("Failed to change memory protection.") << std::endl;
+		}
+	}
+	else
+	{
+		std::cerr << "Failed to find instruction in OVR dll!" << std::endl;
+	}
+
+	return;
+}
+
+} // namespace HOL::hacks

--- a/HandOfLesser/src/openxr_hacks.h
+++ b/HandOfLesser/src/openxr_hacks.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <windows.h>	// Because HANDLE
+
+namespace HOL::hacks
+{
+
+	void fixOvrSessionStateRestriction();
+	HMODULE getModule(HANDLE hProcess, const TCHAR moduleName[]);
+}


### PR DESCRIPTION
## The problem

As of couple of weeks ago, Airlink requires the OpenXR session state to be `FOCUSED` in order to receive any input, including hand tracking. 

You are transitioned to the `FOCUSED` state when you are actively rendering frames to be displayed in the HMD, but you obviously cannot do this while also using SteamVR or VRchat.

## The solution

When using the Airlink OpenXR runtime, Airlink's `XR_EXT_hand_tracking.dll` is loaded and implements that extension. This in turn calls ovr_GetHandPose() in `LibOVRRT64_1.dll`, where the session state check is performed.

Since all of this happens inside our process, we can modify the loaded dll in memory and replace the instructions at the session state check, in our case swapping out a `jnz` instruction for `jz`, essentially flipped the case.

A simple byte search pattern is defined, and we loop through the data of the loaded module ( dll ) in memory until we find it, or the best best.

```cpp
	// Pattern of bytes surrounding the instructions we are looking for,.
	// 0xFF denotes a wildcard
	BYTE targetBytes[] = {

		0x48, 0x8b, 0x05, 0xFF, 0xFF, 0xFF, 0xFF, // mov
		0x48, 0x85, 0xc0,					// test
		0x75, 0x05,						// jnz
		0xe8, 0xFF, 0xFF, 0xFF, 0xFF,			// call

		0x80, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,  // cmp
		0x75, 0xFF,						// jnz	Target!

	};
```
This section of instructions is very unlikely to change unless they mess with the actual code, and is, surprisingly, unique.
If it breaks there are better approaches, they just require a better understanding of what's happening on the `ovr` side.

Once located we swap out that 0x75 for 0x74, and everything works as it did before. 

This also allows for `XR_FB_HAND_TRACKING_AIM_EXTENSION_NAME` ( gestures ) to work, but these are garbage and should be replaced anyway. I have not tested if velocity values are valid. 

As of writing this works for both the stable and the beta channel. 